### PR TITLE
Fix Klipper README links

### DIFF
--- a/Klipper/README.md
+++ b/Klipper/README.md
@@ -5,7 +5,9 @@ Most of the code has been taken from the [TapChanger](https://github.com/viestur
 
 ## Tapchanger Files
 
-You need `homing.cfg`, `macros.cfg`, `tool_detection.cfg` and `toolchanger.cfg` from [TapChanger Example](https://github.com/viesturz/tapchanger/tree/main/Klipper/config-example)
+You need
+- `homing.cfg`, `macros.cfg`, and `toolchanger.cfg` from [TapChanger Examples/per tool probe](https://github.com/viesturz/klipper-toolchanger/tree/main/examples/per%20tool%20probe)
+- [`tool_detection.cfg`](https://github.com/viesturz/klipper-toolchanger/blob/main/examples/tool_detection.cfg)
 
 You can either add them manually to your klipper install, or alternatively, you can integrate them to your config so that moonraker keeps them up to date with your other software if they change. Below are the steps for the integrated way. If you make any changes to the files though, they will be overwritten if you update. If you choose to manually add them, make sure your printer.cfg reflects the location of them.
 


### PR DESCRIPTION
Fix the links to the TapChanger files in the Klipper README.